### PR TITLE
FAST_CPU clock output change to open drain

### DIFF
--- a/src/HX711_2.cpp
+++ b/src/HX711_2.cpp
@@ -32,9 +32,9 @@
 #include <util/atomic.h>
 #endif
 
-#ifdef FAST_CPU
+// Defines the delay(us) between setting the HIGH/LOW modes of the clock pins
 #define DELAY_MICROSECONDS 3
-#endif
+
 static inline void doubleWrite(uint8_t pin1, uint8_t pin2, bool level)
 {
   digitalWrite(pin1, level);

--- a/src/HX711_2.cpp
+++ b/src/HX711_2.cpp
@@ -66,7 +66,7 @@ uint16_t shiftInSlow(uint8_t dataPin, uint8_t dataPin2, uint8_t clockPin, uint8_
   return value2 << 8 | value;
 }
 
-#ifdef FAST_CPU
+#ifdef CLOCK_OUTPUT_MODE
 /* When using a fast MCU and single clock to drive multiple amp boards the use of a 
 exteranal pullup is needed hence the outptu should be defined as open drain. */
 #define SCK_MODE OUTPUT_OPEN_DRAIN

--- a/src/HX711_2.cpp
+++ b/src/HX711_2.cpp
@@ -66,6 +66,14 @@ uint16_t shiftInSlow(uint8_t dataPin, uint8_t dataPin2, uint8_t clockPin, uint8_
   return value2 << 8 | value;
 }
 
+#ifdef FAST_CPU
+/* When using a fast MCU and single clock to drive multiple amp boards the use of a 
+exteranal pullup is needed hence the outptu should be defined as open drain. */
+#define SCK_MODE OUTPUT_OPEN_DRAIN
+#else
+#define SCK_MODE OUTPUT
+#endif
+
 #if ARCH_ESPRESSIF
 // ESP8266 doesn't read values between 0x20000 and 0x30000 when DOUT is pulled up.
 #define DOUT_MODE INPUT
@@ -87,15 +95,9 @@ void HX711_2::begin(byte dout, byte dout2, byte pd_sck, byte pd_sck2, byte gain)
   PD_SCK2 = pd_sck2;
   DOUT = dout;
   DOUT2 = dout2;
-  #ifdef FAST_CPU
-  pinMode(PD_SCK, OUTPUT_OPEN_DRAIN);
+  pinMode(PD_SCK, SCK_MODE);
   if (PD_SCK2 != 255)
-    pinMode(PD_SCK2, OUTPUT_OPEN_DRAIN);
-  #else
-  pinMode(PD_SCK, OUTPUT);
-  if (PD_SCK2 != 255)
-    pinMode(PD_SCK2, OUTPUT);
-  #endif
+    pinMode(PD_SCK2, SCK_MODE);
   pinMode(DOUT, DOUT_MODE);
   pinMode(DOUT2, DOUT_MODE);
 

--- a/src/HX711_2.cpp
+++ b/src/HX711_2.cpp
@@ -48,9 +48,9 @@ uint16_t shiftInSlow(uint8_t dataPin, uint8_t dataPin2, uint8_t clockPin, uint8_
   for (i = 0; i < 8; ++i)
   {
     doubleWrite(clockPin, clockPin2, HIGH);
-    delayMicroseconds(1);
+    delayMicroseconds(3);
     doubleWrite(clockPin, clockPin2, LOW);
-    delayMicroseconds(1);
+    delayMicroseconds(3);
     if (bitOrder == LSBFIRST)
     {
       value |= digitalRead(dataPin) << i;
@@ -87,12 +87,18 @@ void HX711_2::begin(byte dout, byte dout2, byte pd_sck, byte pd_sck2, byte gain)
   PD_SCK2 = pd_sck2;
   DOUT = dout;
   DOUT2 = dout2;
-
+  #ifdef FAST_CPU
+  pinMode(PD_SCK, OUTPUT_OPEN_DRAIN);
+  if (PD_SCK2 != 255)
+    pinMode(PD_SCK2, OUTPUT_OPEN_DRAIN);
+  #else
   pinMode(PD_SCK, OUTPUT);
   if (PD_SCK2 != 255)
     pinMode(PD_SCK2, OUTPUT);
+  #endif
   pinMode(DOUT, DOUT_MODE);
   pinMode(DOUT2, DOUT_MODE);
+
 
   set_gain(gain);
 }
@@ -184,11 +190,11 @@ void HX711_2::read(long *readValues, unsigned long timeout)
     {
       doubleWrite(PD_SCK, PD_SCK2, HIGH);
 #if FAST_CPU
-      delayMicroseconds(1);
+      delayMicroseconds(3);
 #endif
       doubleWrite(PD_SCK, PD_SCK2, LOW);
 #if FAST_CPU
-      delayMicroseconds(1);
+      delayMicroseconds(3);
 #endif
     }
 
@@ -345,7 +351,7 @@ void HX711_2::read(long *readValues, unsigned long timeout)
   {
     doubleWrite(PD_SCK, PD_SCK2, LOW);
 #if FAST_CPU
-    delayMicroseconds(1);
+    delayMicroseconds(3);
 #endif
     doubleWrite(PD_SCK, PD_SCK2, HIGH);
   }

--- a/src/HX711_2.cpp
+++ b/src/HX711_2.cpp
@@ -84,7 +84,7 @@ HX711_2::~HX711_2()
 {
 }
 
-void HX711_2::begin(byte dout, byte dout2, byte pd_sck, byte pd_sck2, byte gain, char sck_mode)
+void HX711_2::begin(byte dout, byte dout2, byte pd_sck, byte pd_sck2, byte gain, unsigned char sck_mode)
 {
   PD_SCK = pd_sck;
   PD_SCK2 = pd_sck2;

--- a/src/HX711_2.h
+++ b/src/HX711_2.h
@@ -40,7 +40,8 @@ class HX711_2
 		// - With a gain factor of 64 or 128, channel A is selected
 		// - With a gain factor of 32, channel B is selected
 		// The library default is "128" (Channel A).
-		void begin(byte dout, byte dout2, byte pd_sck, byte pd_sck2 = 255, byte gain = 128);
+		// Clock pins can be switched in different mode passing a mode MACRO as the last param, defaults to OUTPUT.
+		void begin(byte dout, byte dout2, byte pd_sck, byte pd_sck2 = 255, byte gain = 128, char sck_mode = OUTPUT);
 
 		// Check if HX711 is ready
 		// from the datasheet: When output data is not ready for retrieval, digital output pin DOUT is high. Serial clock

--- a/src/HX711_2.h
+++ b/src/HX711_2.h
@@ -41,7 +41,7 @@ class HX711_2
 		// - With a gain factor of 32, channel B is selected
 		// The library default is "128" (Channel A).
 		// Clock pins can be switched in different mode passing a mode MACRO as the last param, defaults to OUTPUT.
-		void begin(byte dout, byte dout2, byte pd_sck, byte pd_sck2 = 255, byte gain = 128, char sck_mode = OUTPUT);
+		void begin(byte dout, byte dout2, byte pd_sck, byte pd_sck2 = 255, byte gain = 128, unsigned char sck_mode = OUTPUT);
 
 		// Check if HX711 is ready
 		// from the datasheet: When output data is not ready for retrieval, digital output pin DOUT is high. Serial clock


### PR DESCRIPTION
Changes the operating mode for the clock pins to OUTPUT_OPEN_DRAIN when on a FAST_CPU so a resistor can act as a external 5v pullup. Tested and working solution.